### PR TITLE
[Feat] OAuth2 로그인 (Google, Naver, Kakao) 초기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,19 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ranpo/ranpobackend/auth/service/AuthService.java
+++ b/src/main/java/com/ranpo/ranpobackend/auth/service/AuthService.java
@@ -1,0 +1,63 @@
+package com.ranpo.ranpobackend.auth.service;
+
+import com.ranpo.ranpobackend.global.auth.oauth2.userinfo.OAuth2UserInfo;
+import com.ranpo.ranpobackend.global.exception.CustomException;
+import com.ranpo.ranpobackend.global.exception.ErrorCode;
+import com.ranpo.ranpobackend.global.util.IdGenerator;
+import com.ranpo.ranpobackend.member.domain.Member;
+import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
+import com.ranpo.ranpobackend.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public boolean checkIfMemberExists(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public Member socialLogin(OAuth2UserInfo userInfo) {
+        Member member = getMemberByEmail(userInfo.getEmail());
+
+        // DB와 현재 요청한 Provider와 일치하다면 로그인 처리
+        if (member.getProviderType().equals(userInfo.getProviderType())) {
+            return member;
+        }
+
+        // 로그인 실패, 다른 Provider로 로그인 유도
+        throw new OAuth2AuthenticationException(
+                new OAuth2Error(
+                        ErrorCode.PROVIDER_TYPE_MISMATCH.getCode(),
+                        ErrorCode.PROVIDER_TYPE_MISMATCH.getMessage()
+                                + " " + member.getProviderType().name() + "로 로그인해주세요.",
+                        null
+                )
+        );
+    }
+
+    @Transactional
+    public Member register(OAuth2UserInfo userInfo) {
+        Member member = Member.builder()
+                        .email(userInfo.getEmail())
+                        .nickname(userInfo.getNickname())
+                        .uid(IdGenerator.generateUuidUid())
+                        .providerType(userInfo.getProviderType())
+                        .role(MemberRole.USER)
+                        .build();
+        return memberRepository.save(member);
+    }
+
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> CustomException.from(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.ranpo.ranpobackend.global.auth.jwt;
+
+import com.ranpo.ranpobackend.global.auth.dto.CurrentUser;
+import com.ranpo.ranpobackend.global.exception.CustomException;
+import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = jwtProvider.substringToken(authHeader);
+
+            try {
+                Claims claims = jwtProvider.extractClaims(token);
+
+                if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                    setAuthentication(claims);
+                }
+            } catch (CustomException e) {
+                SecurityContextHolder.clearContext();
+                throw e;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(Claims claims) {
+        Long id = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+        String nickname = claims.get("nickname", String.class);
+        MemberRole memberRole = MemberRole.valueOf(claims.get("memberRole", String.class));
+
+        CurrentUser currentUser = new CurrentUser(id, email, nickname, memberRole);
+        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(currentUser);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,25 @@
+package com.ranpo.ranpobackend.global.auth.jwt;
+
+import com.ranpo.ranpobackend.global.auth.dto.CurrentUser;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final CurrentUser currentUser;
+
+    public JwtAuthenticationToken(CurrentUser currentUser) {
+        super(currentUser.getAuthorities());
+        this.currentUser = currentUser;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return currentUser;
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtProvider.java
@@ -1,0 +1,74 @@
+package com.ranpo.ranpobackend.global.auth.jwt;
+
+import com.ranpo.ranpobackend.global.exception.CustomException;
+import com.ranpo.ranpobackend.global.exception.ErrorCode;
+import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, String email, String nickname, MemberRole memberRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("email", email)
+                        .claim("memberRole", memberRole)
+                        .claim("nickname", nickname)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date) // 발급일
+                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(BEARER_PREFIX.length());
+        }
+        throw CustomException.from(ErrorCode.INVALID_TOKEN_FORMAT);
+    }
+
+    public Claims extractClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (MalformedJwtException | IllegalArgumentException e) { // 형식이 잘못되거나 빈 값
+            throw CustomException.from(ErrorCode.INVALID_TOKEN_FORMAT);
+        } catch (SecurityException e) { // 서명 검증 실패 (위조된 토큰)
+            throw CustomException.from(ErrorCode.INVALID_TOKEN_SIGNATURE);
+        } catch (ExpiredJwtException e) { // 만료된 토큰
+            throw CustomException.from(ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException e) { // fallback
+            throw CustomException.from(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,40 @@
+package com.ranpo.ranpobackend.global.auth.oauth2;
+
+import com.ranpo.ranpobackend.member.domain.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Member member;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(Member member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return  List.of(new SimpleGrantedAuthority(member.getRole().toRoleName()));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(member.getId()); // 인증 식별자
+    }
+
+    public Member getMember() {
+        return member;
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.ranpo.ranpobackend.global.auth.oauth2;
+
+import com.ranpo.ranpobackend.auth.service.AuthService;
+import com.ranpo.ranpobackend.global.auth.oauth2.userinfo.OAuth2UserInfo;
+import com.ranpo.ranpobackend.global.auth.oauth2.userinfo.OAuth2UserInfoFactory;
+import com.ranpo.ranpobackend.member.domain.Member;
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+/**
+ * 1. code를 전송하여 발급받은 accessToken으로 사용자 정보를 조회
+ * 2. 해당 정보로 회원가입 or 로그인 진행
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final AuthService authService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest); // 사용자 정보 가져오기
+        ProviderType providerType = extractProviderType(userRequest); // Provider 가져오기
+
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, oAuth2User.getAttributes());
+
+        Member member = processOAuth2Login(userInfo);
+
+        return new CustomOAuth2User(member, oAuth2User.getAttributes());
+    }
+
+    private Member processOAuth2Login(OAuth2UserInfo userInfo) {
+        // 1. 이미 이메일 존재
+        if (authService.checkIfMemberExists(userInfo.getEmail())) {
+            return authService.socialLogin(userInfo);
+        }
+
+        // 2. 이메일 존재 X
+        return authService.register(userInfo);
+    }
+
+    private ProviderType extractProviderType(OAuth2UserRequest userRequest) {
+        String providerName = userRequest.getClientRegistration().getRegistrationId();
+        return ProviderType.from(providerName);
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,39 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException, ServletException {
+        exception.printStackTrace();
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = "소셜 로그인에 실패했습니다.";
+        if (exception instanceof OAuth2AuthenticationException authEx) {
+            message = authEx.getError().getDescription();
+        }
+
+        String encodedMessage = URLEncoder.encode(message, StandardCharsets.UTF_8);
+        response.sendRedirect("http://localhost:3000/oauth2/redirect?error=" + encodedMessage);
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,44 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.handler;
+
+import com.ranpo.ranpobackend.global.auth.jwt.JwtProvider;
+import com.ranpo.ranpobackend.global.auth.oauth2.CustomOAuth2User;
+import com.ranpo.ranpobackend.member.domain.Member;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        Member member = oAuth2User.getMember();
+
+        String token = jwtProvider.createToken(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole()
+        );
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"accessToken\": \"" + token + "\"}");
+        response.sendRedirect("http://localhost:3000/oauth2/redirect");
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/GoogleUserInfo.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/GoogleUserInfo.java
@@ -1,0 +1,22 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.userinfo;
+
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+
+import java.util.Map;
+
+public class GoogleUserInfo extends OAuth2UserInfo {
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        super(ProviderType.GOOGLE, attributes);
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/KakaoUserInfo.java
@@ -1,0 +1,22 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.userinfo;
+
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+
+import java.util.Map;
+
+public class KakaoUserInfo extends OAuth2UserInfo {
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        super(ProviderType.KAKAO, (Map<String, Object>) attributes.get("kakao_account") );
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("nickname");
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/NaverUserInfo.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/NaverUserInfo.java
@@ -1,0 +1,22 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.userinfo;
+
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+
+import java.util.Map;
+
+public class NaverUserInfo extends OAuth2UserInfo {
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        super(ProviderType.NAVER, (Map<String, Object>) attributes.get("response"));
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.userinfo;
+
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected ProviderType providerType;
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+        this.providerType = providerType;
+        this.attributes = attributes;
+    }
+
+    public ProviderType getProviderType() {
+        return providerType;
+    }
+
+    abstract public String getEmail();
+    abstract public String getNickname();
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/userinfo/OAuth2UserInfoFactory.java
@@ -1,0 +1,15 @@
+package com.ranpo.ranpobackend.global.auth.oauth2.userinfo;
+
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+        return switch (providerType) {
+            case GOOGLE -> new GoogleUserInfo(attributes);
+            case KAKAO -> new KakaoUserInfo(attributes);
+            case NAVER -> new NaverUserInfo(attributes);
+        };
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package com.ranpo.ranpobackend.global.config;
+
+import com.ranpo.ranpobackend.global.auth.jwt.JwtAuthenticationFilter;
+import com.ranpo.ranpobackend.global.auth.jwt.JwtProvider;
+import com.ranpo.ranpobackend.global.auth.oauth2.CustomOAuth2UserService;
+import com.ranpo.ranpobackend.global.auth.oauth2.handler.OAuth2LoginFailureHandler;
+import com.ranpo.ranpobackend.global.auth.oauth2.handler.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtProvider jwtProvider) throws Exception {
+        return http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/login/**", "/oauth2/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/exception/ErrorCode.java
@@ -20,6 +20,11 @@ public enum ErrorCode {
     // OAuth2 로그인 : OAUTH2
     PROVIDER_TYPE_MISMATCH("OAUTH2_001", HttpStatus.BAD_REQUEST, "이미 해당 이메일로 가입된 계정이 존재합니다."),
 
+    // 인증/인가 : AUTH
+    INVALID_TOKEN_FORMAT("AUTH_001", HttpStatus.BAD_REQUEST, "잘못된 형식의 토큰입니다."),
+    EXPIRED_TOKEN("AUTH_002", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN_SIGNATURE("AUTH_003", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 서명입니다."),
+    INVALID_TOKEN("AUTH_004", HttpStatus.UNAUTHORIZED, "토큰 검증에 실패했습니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/ranpo/ranpobackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/exception/ErrorCode.java
@@ -15,7 +15,11 @@ public enum ErrorCode {
 
     // 사용자 : USER
     USER_NOT_FOUND("USER_001", HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    EMAIL_ALREADY_EXISTS("USER_002", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+    EMAIL_ALREADY_EXISTS("USER_002", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+
+    // OAuth2 로그인 : OAUTH2
+    PROVIDER_TYPE_MISMATCH("OAUTH2_001", HttpStatus.BAD_REQUEST, "이미 해당 이메일로 가입된 계정이 존재합니다."),
+
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/ranpo/ranpobackend/global/util/IdGenerator.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/util/IdGenerator.java
@@ -1,0 +1,10 @@
+package com.ranpo.ranpobackend.global.util;
+
+import java.util.UUID;
+
+public class IdGenerator {
+
+    public static String generateUuidUid() {
+        return "u" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/member/domain/Member.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/domain/Member.java
@@ -1,10 +1,14 @@
 package com.ranpo.ranpobackend.member.domain;
 
+import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
+import com.ranpo.ranpobackend.member.domain.enums.ProviderType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
@@ -21,12 +26,31 @@ public class Member {
     @Column(nullable = false)
     private String email;
 
+    @Column(unique = true, nullable = false)
+    private String uid;
+
     @Column(nullable = false, length = 20)
     private String nickname;
 
     private String phone;
 
+    @Enumerated(EnumType.STRING)
+    private ProviderType providerType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public Member(String email, String nickname, String uid, MemberRole role, ProviderType providerType) {
+        this.email = email;
+        this.nickname = nickname;
+        this.uid = uid;
+        this.role = role;
+        this.providerType = providerType;
+    }
 }

--- a/src/main/java/com/ranpo/ranpobackend/member/domain/enums/MemberRole.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/domain/enums/MemberRole.java
@@ -1,0 +1,10 @@
+package com.ranpo.ranpobackend.member.domain.enums;
+
+public enum MemberRole {
+    USER,
+    ADMIN;
+
+    public String toRoleName() {
+        return "ROLE_" + this.name(); // Spring Security "ROLE_" prefix 관례
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/member/domain/enums/ProviderType.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/domain/enums/ProviderType.java
@@ -1,0 +1,13 @@
+package com.ranpo.ranpobackend.member.domain.enums;
+
+public enum ProviderType {
+    GOOGLE, KAKAO, NAVER;
+
+    public static ProviderType from(String registrationId) {
+        try {
+            return ProviderType.valueOf(registrationId.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("지원하지 않는 소셜 로그인 타입입니다: " + registrationId);
+        }
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/domain/repository/MemberRepository.java
@@ -3,5 +3,10 @@ package com.ranpo.ranpobackend.member.domain.repository;
 import com.ranpo.ranpobackend.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/ranpo/ranpobackend/member/service/MemberService.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.ranpo.ranpobackend.member.service;
+
+import com.ranpo.ranpobackend.global.exception.CustomException;
+import com.ranpo.ranpobackend.global.exception.ErrorCode;
+import com.ranpo.ranpobackend.member.domain.Member;
+import com.ranpo.ranpobackend.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> CustomException.from(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/poll/domain/Poll.java
+++ b/src/main/java/com/ranpo/ranpobackend/poll/domain/Poll.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "polls")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Poll {
 
     @Id
@@ -37,10 +39,13 @@ public class Poll {
 
     private LocalDateTime endAt;
 
+    @Enumerated(EnumType.STRING)
     private AuthType authType;
 
+    @Enumerated(EnumType.STRING)
     private WinnerSelectType winnerSelectType;
 
+    @Enumerated(EnumType.STRING)
     private WinnerScope winnerScope;
 
     private int totalWinnerCount;
@@ -49,8 +54,10 @@ public class Poll {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "poll_reward_id")
+    @Enumerated(EnumType.STRING)
     private PollReward pollReward;
 
+    @Enumerated(EnumType.STRING)
     private RewardMethod rewardMethod;
 
     @CreatedDate

--- a/src/main/java/com/ranpo/ranpobackend/poll/domain/PollOption.java
+++ b/src/main/java/com/ranpo/ranpobackend/poll/domain/PollOption.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "poll_options")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class PollOption {
 
     @Id

--- a/src/main/java/com/ranpo/ranpobackend/reward/domain/PollReward.java
+++ b/src/main/java/com/ranpo/ranpobackend/reward/domain/PollReward.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -13,12 +14,14 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "poll_rewards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class PollReward {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private RewardType type;
 
     private String value;

--- a/src/main/java/com/ranpo/ranpobackend/vote/domain/Vote.java
+++ b/src/main/java/com/ranpo/ranpobackend/vote/domain/Vote.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "votes")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Vote {
 
     @Id

--- a/src/main/java/com/ranpo/ranpobackend/voter/domain/Voter.java
+++ b/src/main/java/com/ranpo/ranpobackend/voter/domain/Voter.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "voters")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Voter {
 
     @Id
@@ -25,6 +27,7 @@ public class Voter {
     @JoinColumn(name = "poll_id")
     private Poll poll;
 
+    @Enumerated(EnumType.STRING)
     private AuthType authType;
 
     private String email;

--- a/src/main/java/com/ranpo/ranpobackend/winner/domain/PollWinner.java
+++ b/src/main/java/com/ranpo/ranpobackend/winner/domain/PollWinner.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "poll_winners")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class PollWinner {
 
     @Id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,75 @@ spring:
     name: ranpo-backend
   profiles:
     active: local
+---
+# Datasource
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+---
+# JPA
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+---
+# OAuth2
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: ${OAUTH2_REDIRECT_URI_GOOGLE}
+            client-id: ${OAUTH2_CLIENT_ID_GOOGLE}
+            client-secret: ${OAUTH2_CLIENT_SECRET_GOOGLE}
+            scope:
+              - email
+              - profile
+          naver:
+            redirect-uri: ${OAUTH2_REDIRECT_URI_NAVER}
+            client-id: ${OAUTH2_CLIENT_ID_NAVER}
+            client-secret: ${OAUTH2_CLIENT_SECRET_NAVER}
+            authorization-grant-type: authorization_code
+            client-name: naver
+            scope:
+              - name
+              - email
+          kakao:
+            redirect-uri: ${OAUTH2_REDIRECT_URI_KAKAO}
+            client-id: ${OAUTH2_CLIENT_ID_KAKAO}
+            client-secret: ${OAUTH2_CLIENT_SECRET_KAKAO}
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: kakao
+            scope:
+              - profile_nickname
+              - profile_image
+              - account_email
+        provider:
+          google:
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+---
+# JWT
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📄 작업 내용
- Google, Naver, Kakao 로그인 구현

## 📎 연관된 이슈
closes #6 

## 💬 기타 사항 or 추가 코멘트

> 기타 남기고 싶은 정보나 참고 자료가 있다면 기록해주세요.
- 현재 `oauth2-client`를 사용해서 code & access token를 모두 가져오고 로그인 성공 & 실패시 모두 프론트로 리다이렉트하고 있음
- code는 프론트에서 받아와 access token만 요청하고 프론트로 access token을 response body로 응답하도록 수정 필요