### PR TITLE
[Feat] 소셜 로그인 완료 시 쿠키에 accessToken를 포함시켜 리다이렉트한다

### DIFF
--- a/src/main/java/com/ranpo/ranpobackend/global/annotation/LoginUser.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/annotation/LoginUser.java
@@ -1,0 +1,12 @@
+package com.ranpo.ranpobackend.global.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface LoginUser {
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/dto/AuthenticatedUser.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/dto/AuthenticatedUser.java
@@ -1,0 +1,27 @@
+package com.ranpo.ranpobackend.global.auth.dto;
+
+import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class AuthenticatedUser {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final MemberRole memberRole;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AuthenticatedUser(Long id, String email, String nickname, MemberRole memberRole) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.memberRole = memberRole;
+        this.authorities = List.of(new SimpleGrantedAuthority(memberRole.toRoleName()));
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.ranpo.ranpobackend.global.auth.jwt;
 
-import com.ranpo.ranpobackend.global.auth.dto.CurrentUser;
+import com.ranpo.ranpobackend.global.auth.dto.AuthenticatedUser;
+import com.ranpo.ranpobackend.global.auth.jwt.resolver.JwtResolver;
 import com.ranpo.ranpobackend.global.exception.CustomException;
 import com.ranpo.ranpobackend.member.domain.enums.MemberRole;
 import io.jsonwebtoken.Claims;
@@ -20,6 +21,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final JwtResolver jwtResolver;
 
     @Override
     protected void doFilterInternal(
@@ -27,11 +29,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
+        String token = jwtResolver.resolve(request);
 
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String token = jwtProvider.substringToken(authHeader);
-
+        if (token != null) {
             try {
                 Claims claims = jwtProvider.extractClaims(token);
 
@@ -53,8 +53,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String nickname = claims.get("nickname", String.class);
         MemberRole memberRole = MemberRole.valueOf(claims.get("memberRole", String.class));
 
-        CurrentUser currentUser = new CurrentUser(id, email, nickname, memberRole);
-        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(currentUser);
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser(id, email, nickname, memberRole);
+        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authenticatedUser);
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
     }
 }

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/JwtAuthenticationToken.java
@@ -1,15 +1,15 @@
 package com.ranpo.ranpobackend.global.auth.jwt;
 
-import com.ranpo.ranpobackend.global.auth.dto.CurrentUser;
+import com.ranpo.ranpobackend.global.auth.dto.AuthenticatedUser;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
-    private final CurrentUser currentUser;
+    private final AuthenticatedUser authenticatedUser;
 
-    public JwtAuthenticationToken(CurrentUser currentUser) {
-        super(currentUser.getAuthorities());
-        this.currentUser = currentUser;
+    public JwtAuthenticationToken(AuthenticatedUser authenticatedUser) {
+        super(authenticatedUser.getAuthorities());
+        this.authenticatedUser = authenticatedUser;
         setAuthenticated(true);
     }
 
@@ -20,6 +20,6 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return currentUser;
+        return authenticatedUser;
     }
 }

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/CookieJwtResolver.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/CookieJwtResolver.java
@@ -1,0 +1,22 @@
+package com.ranpo.ranpobackend.global.auth.jwt.resolver;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "jwt.source", havingValue = "cookie")
+@Component
+public class CookieJwtResolver implements JwtResolver {
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if ("accessToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/HeaderJwtResolver.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/HeaderJwtResolver.java
@@ -1,0 +1,19 @@
+package com.ranpo.ranpobackend.global.auth.jwt.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "jwt.source", havingValue = "header")
+@Component
+public class HeaderJwtResolver implements JwtResolver {
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/JwtResolver.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/jwt/resolver/JwtResolver.java
@@ -1,0 +1,7 @@
+package com.ranpo.ranpobackend.global.auth.jwt.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface JwtResolver {
+    String resolve(HttpServletRequest request);
+}

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -2,8 +2,10 @@ package com.ranpo.ranpobackend.global.auth.oauth2.handler;
 
 import com.ranpo.ranpobackend.global.auth.jwt.JwtProvider;
 import com.ranpo.ranpobackend.global.auth.oauth2.CustomOAuth2User;
+import com.ranpo.ranpobackend.global.util.CookieUtil;
 import com.ranpo.ranpobackend.member.domain.Member;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +14,15 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
+    private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(
@@ -35,10 +40,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 member.getNickname(),
                 member.getRole()
         );
+        String encodedToken = URLEncoder.encode(token, StandardCharsets.UTF_8);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write("{\"accessToken\": \"" + token + "\"}");
+
+        Cookie accessTokenCookie = cookieUtil.createAccessTokenCookie(encodedToken, null);
+        response.addCookie(accessTokenCookie);
+
         response.sendRedirect("http://localhost:3000/oauth2/redirect");
     }
 }

--- a/src/main/java/com/ranpo/ranpobackend/global/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/auth/security/config/SecurityConfig.java
@@ -1,7 +1,8 @@
-package com.ranpo.ranpobackend.global.config;
+package com.ranpo.ranpobackend.global.auth.security.config;
 
 import com.ranpo.ranpobackend.global.auth.jwt.JwtAuthenticationFilter;
 import com.ranpo.ranpobackend.global.auth.jwt.JwtProvider;
+import com.ranpo.ranpobackend.global.auth.jwt.resolver.JwtResolver;
 import com.ranpo.ranpobackend.global.auth.oauth2.CustomOAuth2UserService;
 import com.ranpo.ranpobackend.global.auth.oauth2.handler.OAuth2LoginFailureHandler;
 import com.ranpo.ranpobackend.global.auth.oauth2.handler.OAuth2LoginSuccessHandler;
@@ -31,7 +32,7 @@ public class SecurityConfig {
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtProvider jwtProvider) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtProvider jwtProvider, JwtResolver jwtResolver) throws Exception {
         return http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
@@ -52,7 +53,7 @@ public class SecurityConfig {
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler)
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, jwtResolver), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
@@ -60,7 +61,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000")); // TODO : 실제 도메인으로 변경 필요
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/ranpo/ranpobackend/global/util/CookieUtil.java
+++ b/src/main/java/com/ranpo/ranpobackend/global/util/CookieUtil.java
@@ -1,0 +1,32 @@
+package com.ranpo.ranpobackend.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public static final int ACCESS_TOKEN_EXPIRY = 60 * 60; // 1시간
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    public Cookie createAccessTokenCookie(String token, String domain) {
+        Cookie cookie = new Cookie("accessToken", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(cookieSecure); // 운영 환경에 따라
+        cookie.setPath("/");
+        cookie.setMaxAge(ACCESS_TOKEN_EXPIRY);
+        if (domain != null) cookie.setDomain(domain);
+        return cookie;
+    }
+
+    public static void expireCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/member/controller/MemberController.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package com.ranpo.ranpobackend.member.controller;
+
+import com.ranpo.ranpobackend.global.annotation.LoginUser;
+import com.ranpo.ranpobackend.global.auth.dto.AuthenticatedUser;
+import com.ranpo.ranpobackend.global.dto.response.ApiResponse;
+import com.ranpo.ranpobackend.member.dto.response.MyProfileResponse;
+import com.ranpo.ranpobackend.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/api/members/me")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
+            @LoginUser AuthenticatedUser authenticatedUser
+    ) {
+        return ApiResponse.onSuccess(MyProfileResponse.from(authenticatedUser));
+    }
+}

--- a/src/main/java/com/ranpo/ranpobackend/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/ranpo/ranpobackend/member/dto/response/MyProfileResponse.java
@@ -1,0 +1,27 @@
+package com.ranpo.ranpobackend.member.dto.response;
+
+import com.ranpo.ranpobackend.global.auth.dto.AuthenticatedUser;
+import com.ranpo.ranpobackend.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MyProfileResponse {
+
+    private final Long id;
+    private final String email;
+    private final String nickname;
+
+    private MyProfileResponse(Long id, String email, String nickname) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public static MyProfileResponse from(AuthenticatedUser user) {
+        return new MyProfileResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,3 +75,8 @@ spring:
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}
+  source: ${JWT_EXTRACT_SOURCE}
+---
+# Cookie
+cookie:
+  secure: ${COOKIE_SECURE}


### PR DESCRIPTION
## 📄 작업 내용
1. CookieUtil 작성 : accessToken 쿠키를 설정하여 반환하는 메서드 포함
2. JWT 파싱 모듈 (JwtResolver) 구현 
    - yml 파일의 `jwt.source`에 따라 HeaderJwtResolver 혹은 CookieJwtResolver가 사용됩니다.
    - `HeaderJwtResolver` : 'Bearer' prefix가 붙어 header에 포함된 JWT를 파싱
    - `CookieJwtResolver` : 'accessToken' 이름의 Cookie로 들어있는 JWT를 파싱
3. 기존 인증한 정보를 넣었던 CurrentUser 객체를 AuthenticatedUser로 네이밍을 변경했습니다.
4. `@LoginUser` 어노테이션을 구현하여 파라미터로 AuthenticatedUser를 가져올 수 있도록 하였습니다.

## 📎 연관된 이슈

> 작업 내용이 어떤 이슈와 관련이 있는지 작성해주세요.

## 💬 기타 사항 or 추가 코멘트

> 기타 남기고 싶은 정보나 참고 자료가 있다면 기록해주세요.
